### PR TITLE
Add Streamlit care provider tracker

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,0 +1,11 @@
+[cqc]
+api_key = "YOUR_CQC_API_KEY"
+
+[companies_house]
+api_key = "YOUR_COMPANIES_HOUSE_API_KEY"
+
+[auth]
+# Example credentials for streamlit-authenticator
+# Replace with hashed passwords if using
+usernames = ["demo"]
+passwords = ["demo"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Core-Data-Tracker
+# Core Data Tracker
+
+Streamlit application for tracking care provider information using the CQC Syndication API and Companies House. Users can search by postcode, name or region, compare results against previous CSV uploads and schedule regular data checks.
+
+## Features
+- Search the CQC API for locations and providers
+- Optional lookup of Companies House details by registration number
+- Paginated, searchable results table
+- Compare new results with uploaded CSVs and highlight differences
+- Export results or change reports as CSV
+- Schedule weekly job-ad scraping and monthly change reports
+- Basic user profile preferences stored in session state
+
+## Setup
+1. Install requirements
+```bash
+pip install -r requirements.txt
+```
+2. Add API keys to `.streamlit/secrets.toml` (see provided template).
+3. Run the app
+```bash
+streamlit run app.py
+```
+
+The application is designed to be deployable on Streamlit Cloud.

--- a/app.py
+++ b/app.py
@@ -1,57 +1,154 @@
-# app.py
-import streamlit as st
+import csv
+import io
+import threading
+import time
+from datetime import date, datetime, timedelta
+from typing import List, Dict
+
 import pandas as pd
-from datetime import datetime, timedelta
-import cqc_api  # assumes cqc_api.py is in the same directory
+import requests
+import schedule
+import streamlit as st
 
-# === STREAMLIT SETUP ===
+import cqc_api
+import company_api
+import job_scraper
+
 st.set_page_config(page_title="Care Provider Tracker", layout="wide")
-st.title("Care Provider Tracker - TQ & PL Postcodes")
 
-# === SIDEBAR ===
-st.sidebar.header("Options")
-option = st.sidebar.radio("Choose a tool:", ["API Updates", "Manual Lookup", "About"])
+# --- Authentication (optional) ---
+try:
+    import streamlit_authenticator as stauth
+    credentials = {
+        "usernames": st.secrets.get("auth", {}).get("usernames", []),
+        "passwords": st.secrets.get("auth", {}).get("passwords", []),
+    }
+    if credentials["usernames"]:
+        authenticator = stauth.Authenticate({u: p for u, p in zip(credentials["usernames"], credentials["passwords"])} , 'some_cookie', 'random_key', cookie_expiry_days=1)
+        name, auth_status, username = authenticator.login('Login', 'main')
+        if not auth_status:
+            st.stop()
+except Exception:
+    pass
 
-# === API UPDATES TAB ===
-if option == "API Updates":
-    st.subheader("Live CQC Change Feed")
-    start_date = st.date_input("Start Date", value=datetime.now().date() - timedelta(days=14))
-    end_date = st.date_input("End Date", value=datetime.now().date())
+# --- Helpers ---
+PAGE_SIZE = 20
 
-    if st.button("Fetch Changes"):
-        with st.spinner("Fetching changed locations from CQC..."):
-            changes = cqc_api.get_changes(start_date, end_date)
-            if changes:
-                st.success(f"{len(changes)} changes found.")
-                change_ids = [change.get("id") for change in changes]
-                st.dataframe(pd.DataFrame(change_ids, columns=["Changed Location IDs"]))
-            else:
-                st.info("No changes found in this timeframe.")
 
-# === MANUAL LOOKUP TAB ===
-elif option == "Manual Lookup":
-    st.subheader("Manually Look Up a Location")
-    location_id = st.text_input("Enter Location ID (e.g., 1-1234567890)")
-    if st.button("Fetch Location Info") and location_id:
-        with st.spinner("Fetching location details..."):
+def paginate_df(df: pd.DataFrame, page: int) -> pd.DataFrame:
+    start = page * PAGE_SIZE
+    end = start + PAGE_SIZE
+    return df.iloc[start:end]
+
+
+def compare_data(current: pd.DataFrame, previous: pd.DataFrame) -> pd.DataFrame:
+    diffs = []
+    for _, row in current.iterrows():
+        match = previous[previous['locationId'] == row['locationId']]
+        if not match.empty:
+            old = match.iloc[0]
+            for col in ['phone', 'email', 'registeredManager']:
+                if row.get(col) != old.get(col):
+                    diffs.append({
+                        'locationId': row['locationId'],
+                        'field': col,
+                        'old': old.get(col),
+                        'new': row.get(col)
+                    })
+    return pd.DataFrame(diffs)
+
+
+# --- Scheduler thread ---
+
+def scheduler_thread():
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if 'scheduler_started' not in st.session_state:
+    st.session_state.scheduler_started = False
+
+if not st.session_state.scheduler_started:
+    threading.Thread(target=scheduler_thread, daemon=True).start()
+    st.session_state.scheduler_started = True
+
+
+# --- Sidebar ---
+st.sidebar.header('Search')
+query = st.sidebar.text_input('Postcode, care home name, or region')
+company_no = st.sidebar.text_input('Company Registration Number (optional)')
+if st.sidebar.button('Search') and query:
+    with st.spinner('Searching CQC...'):
+        try:
+            data = cqc_api.search_locations(query)
+            st.session_state.results = pd.json_normalize(data)
+        except Exception as e:
+            st.error(f'Error searching CQC: {e}')
+            st.session_state.results = pd.DataFrame()
+    if company_no:
+        with st.spinner('Fetching company info...'):
             try:
-                location = cqc_api.get_location_by_id(location_id)
-                st.json(location)
+                st.session_state.company = company_api.get_company(company_no)
             except Exception as e:
-                st.error(f"Error: {e}")
+                st.error(f'Error fetching company: {e}')
+                st.session_state.company = {}
 
-# === ABOUT TAB ===
-elif option == "About":
-    st.subheader("About This App")
-    st.markdown("""
-    This tool connects to the **CQC Syndication API** to:
-    - Track care provider updates in real time
-    - Search by Location ID
-    - Help sales teams identify active, changed, or new care settings
+# --- Results ---
+results = st.session_state.get('results')
+if isinstance(results, pd.DataFrame) and not results.empty:
+    search_filter = st.text_input('Filter results')
+    filtered = results[results.apply(lambda r: search_filter.lower() in r.to_string().lower(), axis=1)] if search_filter else results
+    pages = (len(filtered) - 1) // PAGE_SIZE + 1
+    page = st.number_input('Page', 0, max(pages-1, 0), 0)
+    st.dataframe(paginate_df(filtered, int(page)))
+    csv_data = filtered.to_csv(index=False)
+    st.download_button('Export CSV', csv_data, file_name='cqc_results.csv')
+else:
+    st.write('No results yet.')
 
-    🔐 Your API key is stored securely using Streamlit Secrets.
-    """)
-    response = requests.get(url, headers=HEADERS, params=params)
-    response.raise_for_status()
-    return response.json().get("items", [])
+# --- Company info ---
+company = st.session_state.get('company')
+if company:
+    st.subheader('Company House Record')
+    st.json(company)
 
+# --- Upload previous results for comparison ---
+uploaded = st.file_uploader('Upload previous CSV to compare', type='csv')
+if uploaded and isinstance(results, pd.DataFrame) and not results.empty:
+    prev = pd.read_csv(uploaded)
+    diffs = compare_data(results, prev)
+    if not diffs.empty:
+        st.subheader('Detected Changes')
+        st.dataframe(diffs)
+        st.download_button('Download Changes', diffs.to_csv(index=False), file_name='changes.csv')
+    else:
+        st.info('No differences found.')
+
+# --- Scheduling ---
+def weekly_jobs():
+    jobs = job_scraper.search_jobs('care assistant', query)
+    with open('weekly_jobs.csv', 'w', newline='', encoding='utf-8') as f:
+        pd.DataFrame(jobs).to_csv(f, index=False)
+
+def monthly_changes():
+    end = date.today()
+    start = end - timedelta(days=30)
+    changes = cqc_api.get_changes(start, end)
+    with open('monthly_changes.csv', 'w', newline='', encoding='utf-8') as f:
+        pd.DataFrame(changes).to_csv(f, index=False)
+
+if st.sidebar.button('Schedule Weekly Job Scrape'):
+    schedule.every().week.do(weekly_jobs)
+    st.sidebar.success('Weekly job scrape scheduled.')
+
+if st.sidebar.button('Schedule Monthly Change Report'):
+    schedule.every().month.do(monthly_changes)
+    st.sidebar.success('Monthly change report scheduled.')
+
+# --- Profile ---
+st.sidebar.header('Profile')
+region_pref = st.sidebar.text_input('Preferred region', st.session_state.get('region_pref', ''))
+if st.sidebar.button('Save Profile'):
+    st.session_state['region_pref'] = region_pref
+    st.sidebar.success('Profile saved.')

--- a/company_api.py
+++ b/company_api.py
@@ -1,0 +1,16 @@
+import requests
+import streamlit as st
+from typing import Dict
+
+BASE_URL = "https://api.company-information.service.gov.uk"
+
+
+def get_company(reg_number: str) -> Dict:
+    key = st.secrets.get("companies_house", {}).get("api_key")
+    resp = requests.get(
+        f"{BASE_URL}/company/{reg_number}",
+        auth=(key, ""),
+        headers={"Accept": "application/json"},
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/cqc_api.py
+++ b/cqc_api.py
@@ -1,0 +1,41 @@
+import os
+from typing import List, Dict
+from datetime import date
+import requests
+import streamlit as st
+
+BASE_URL = "https://api.service.cqc.org.uk/public/v1"
+
+
+def _headers() -> Dict[str, str]:
+    key = st.secrets.get("cqc", {}).get("api_key")
+    headers = {"Accept": "application/json"}
+    if key:
+        headers["Ocp-Apim-Subscription-Key"] = key
+    return headers
+
+
+def search_locations(query: str) -> List[Dict]:
+    params = {"term": query}
+    r = requests.get(f"{BASE_URL}/locations", headers=_headers(), params=params)
+    r.raise_for_status()
+    return r.json().get("locations", [])
+
+
+def get_location(location_id: str) -> Dict:
+    r = requests.get(f"{BASE_URL}/locations/{location_id}", headers=_headers())
+    r.raise_for_status()
+    return r.json()
+
+
+def get_provider(provider_id: str) -> Dict:
+    r = requests.get(f"{BASE_URL}/providers/{provider_id}", headers=_headers())
+    r.raise_for_status()
+    return r.json()
+
+
+def get_changes(start: date, end: date) -> List[Dict]:
+    params = {"startTimestamp": start.isoformat(), "endTimestamp": end.isoformat()}
+    r = requests.get(f"{BASE_URL}/changes", headers=_headers(), params=params)
+    r.raise_for_status()
+    return r.json().get("changes", [])

--- a/job_scraper.py
+++ b/job_scraper.py
@@ -1,0 +1,25 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import List, Dict
+
+INDEED_URL = "https://uk.indeed.com/jobs"
+
+
+def search_jobs(keyword: str, location: str) -> List[Dict]:
+    params = {"q": keyword, "l": location}
+    resp = requests.get(INDEED_URL, params=params, headers={"User-Agent": "Mozilla/5.0"})
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    jobs = []
+    for card in soup.select("a.tapItem"):
+        title = card.select_one("h2 span").get_text(strip=True)
+        company = card.select_one("span.companyName")
+        summary = card.select_one("div.job-snippet")
+        link = "https://uk.indeed.com" + card.get("href")
+        jobs.append({
+            "title": title,
+            "company": company.get_text(strip=True) if company else "",
+            "summary": summary.get_text(" ", strip=True) if summary else "",
+            "link": link,
+        })
+    return jobs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 streamlit
 pandas
 requests
+beautifulsoup4
+schedule
+streamlit-authenticator


### PR DESCRIPTION
## Summary
- add Streamlit secrets template
- implement API wrappers for CQC and Companies House
- add simple job scraper
- rebuild app with search, comparison, export and scheduling features
- update requirements
- rewrite README

## Testing
- `python -m py_compile app.py cqc_api.py job_scraper.py company_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e72229f488329a88e43a63d84cf88